### PR TITLE
update path-parse to 1.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6810,7 +6810,7 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
+      "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
@@ -13287,7 +13287,7 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
+      "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true


### PR DESCRIPTION
Fix the following.
https://github.com/advisories/GHSA-hj48-42vr-x3v9